### PR TITLE
修复：更新 Star History 图表地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,4 +675,4 @@ go-music-dl/
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=guohuiyuan/go-music-dl&type=date&legend=top-left)](https://www.star-history.com/?repos=guohuiyuan%2Fgo-music-dl&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=guohuiyuan/go-music-dl&type=date&legend=top-left)](https://star-history.dera.page/#guohuiyuan/go-music-dl&type=date&legend=top-left)


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer 接口限制而无法正常显示。本 PR 将图表地址更新至新的域名，确保 Star History 图表能够正常展示。